### PR TITLE
Store attendance codes with expiration

### DIFF
--- a/attendance/attendance_stack.py
+++ b/attendance/attendance_stack.py
@@ -26,8 +26,6 @@ class AttendanceStack(Stack):
             environment= {
                 "DISCORD_PUBLIC_KEY" : os.getenv('DISCORD_PUBLIC_KEY'),
                 "ID" : os.getenv('ID'),
-                "AWS_ID" : os.getenv('AWS_ACCESS_KEY_ID'),
-                "AWS_KEY" : os.getenv('AWS_SECRET_ACCESS_KEY'),
                 "DYNAMO_USERTABLE" : user_table.table_name,
                 "DYNAMO_CODETABLE" : code_table.table_name
             },            

--- a/attendance/attendance_stack.py
+++ b/attendance/attendance_stack.py
@@ -16,8 +16,9 @@ class AttendanceStack(Stack):
     def __init__(self, scope: Construct, construct_id: str, **kwargs) -> None:
         super().__init__(scope, construct_id, **kwargs)
 
-        table = dynamodb.TableV2(self, f"Table{construct_id}", partition_key=dynamodb.Attribute(name="userID", type=dynamodb.AttributeType.STRING))
-        
+        user_table = dynamodb.TableV2(self, f"Table{construct_id}", partition_key=dynamodb.Attribute(name="userID", type=dynamodb.AttributeType.STRING))
+        code_table = dynamodb.TableV2(self, f"Table{construct_id}_Codes", partition_key=dynamodb.Attribute(name="codeID", type=dynamodb.AttributeType.STRING))
+
         dockerFunc = _lambda.DockerImageFunction(
             scope=self,
             id=f"ID{construct_id}",
@@ -39,4 +40,5 @@ class AttendanceStack(Stack):
             proxy=True,
         )
 
-        table.grant_read_write_data(dockerFunc.role)
+        user_table.grant_read_write_data(dockerFunc.role)
+        code_table.grant_read_write_data(dockerFunc.role)

--- a/attendance/attendance_stack.py
+++ b/attendance/attendance_stack.py
@@ -28,6 +28,8 @@ class AttendanceStack(Stack):
                 "ID" : os.getenv('ID'),
                 "AWS_ID" : os.getenv('AWS_ACCESS_KEY_ID'),
                 "AWS_KEY" : os.getenv('AWS_SECRET_ACCESS_KEY'),
+                "DYNAMO_USERTABLE" : user_table.table_name,
+                "DYNAMO_CODETABLE" : code_table.table_name
             },            
             code=_lambda.DockerImageCode.from_image_asset(
                 directory="src"

--- a/commands/discord_commands.yaml
+++ b/commands/discord_commands.yaml
@@ -17,8 +17,21 @@
       required: true
 
 - name: generate
-  description: Generates an attendence code. Can only be used by Guild Administrators
-  
+  description: Generates an attendence code. Can only be used by Guild Administrators.
+  options:
+    - name: expire_in
+      description: Set when the code expires (in minutes from now)
+      type: 4 #int 
+      required: true
+
+- name: validate
+  description: Check if an attendence code is valid. Can only be used by Guild Administrators.
+  options:
+    - name: code
+      description: Event code
+      type: 3 # string
+      required: true
+
 - name: reset
   description: Reset a user's statistics
 

--- a/src/app/db.py
+++ b/src/app/db.py
@@ -23,7 +23,6 @@ def get_code_expiration(code):
     dynamodb = boto3.resource("dynamodb", region_name='us-east-1')
     table = dynamodb.Table(CODE_TABLENAME)
 
-    print(code)
     response = table.get_item(Key={"codeID": code})
 
     expiration = None

--- a/src/app/db.py
+++ b/src/app/db.py
@@ -1,0 +1,34 @@
+import boto3
+import os
+
+AWS_ID = os.getenv("AWS_ACCESS_KEY_ID")
+AWS_SECRET = os.getenv("AWS_SECRET_ACCESS_KEY")
+USER_TABLENAME = os.getenv("DYNAMO_USERTABLE")
+CODE_TABLENAME = os.getenv("DYNAMO_CODETABLE")
+
+# TODO: update user attendance stuff
+
+def write_code(code, expiration):
+    dynamodb = boto3.resource("dynamodb", region_name='us-east-1')
+    table = dynamodb.Table(CODE_TABLENAME)
+
+    response = table.put_item(Item={"codeID": code, "expiration": expiration})
+
+    if response['ResponseMetadata']['HTTPStatusCode'] == 200:
+        print(f"Item {code} added successfully.")
+    else:
+        print("Error adding item...")
+
+def get_code_expiration(code):
+    dynamodb = boto3.resource("dynamodb", region_name='us-east-1')
+    table = dynamodb.Table(CODE_TABLENAME)
+
+    print(code)
+    response = table.get_item(Key={"codeID": code})
+
+    expiration = None
+    if "Item" in response:
+        expiration = response["Item"]["expiration"]
+
+    return expiration
+

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -137,9 +137,8 @@ def validate_code(code: str) -> bool:
     expiration = db.get_code_expiration(code)
 
     valid = False
-    if expiration == None:
-        return valid
+    if expiration != None:
+        expiration = datetime.strptime(expiration, DATETIME_FORMAT)
+        valid = datetime.now() < expiration    
 
-    expiration = datetime.strptime(expiration, DATETIME_FORMAT)
-    valid = datetime.now() < expiration    
     return valid

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -10,27 +10,6 @@ import secrets
 DISCORD_PUBLIC_KEY = os.environ.get("DISCORD_PUBLIC_KEY")
 DATETIME_FORMAT = "%Y-%m-%d %H:%M:%S.%f"
 
-def generate_code(expiration_time: int) -> int:
-    code = secrets.randbelow(900000) + 100000
-
-    expire = datetime.now()
-    expire_time = timedelta(minutes=expiration_time)
-    expire = expire + expire_time
-
-    db.write_code(str(code), expire.strftime(DATETIME_FORMAT))
-    return code
-
-def validate_code(code: str) -> bool:
-    expiration = db.get_code_expiration(code)
-
-    valid = False
-    if expiration == None:
-        return valid
-
-    expiration = datetime.strptime(expiration, DATETIME_FORMAT)
-    valid = datetime.now() < expiration    
-    return valid
-
 def verify(event):
     signature = event['headers']['x-signature-ed25519']
     timestamp = event['headers']['x-signature-timestamp']
@@ -100,8 +79,10 @@ def interact(raw_request):
     match command_name:
         case "generate":
             if admin: 
+                send(f"Generating attendence code...", id, token)
                 minutes = int(data["options"][0]["value"])
-                send(f"Attendence Code is {generate_code(minutes)}.", id, token)
+                code = generate_code(minutes)
+                update(f"Attendence Code is {code}.", token)
             else: send("Only administrators can generate attendance codes", id, token)
         case "validate":
             code = str(data["options"][0]["value"])
@@ -117,7 +98,6 @@ def send(message, id, token):
         "type": 4,
         "data": {
             "content": message,
-            "flags" : 1 << 6
         }
     }
 
@@ -135,7 +115,6 @@ def update(message, token):
     # JSON data to send with the request
     data = {
         "content": message,
-        "flags" : 1 << 6
     }
 
     # Send the PATCH request
@@ -143,3 +122,24 @@ def update(message, token):
 
     print("Response status code: ")
     print(response.status_code)
+
+def generate_code(expiration_time: int) -> int:
+    code = secrets.randbelow(900000) + 100000
+
+    expire = datetime.now()
+    expire_time = timedelta(minutes=expiration_time)
+    expire = expire + expire_time
+
+    db.write_code(str(code), expire.strftime(DATETIME_FORMAT))
+    return code
+
+def validate_code(code: str) -> bool:
+    expiration = db.get_code_expiration(code)
+
+    valid = False
+    if expiration == None:
+        return valid
+
+    expiration = datetime.strptime(expiration, DATETIME_FORMAT)
+    valid = datetime.now() < expiration    
+    return valid


### PR DESCRIPTION
### Overview
This PR adds the functionality to the bot where attendance codes will be stored in a DynamoDB table with an expiration that can be set in minutes from the generation time. Another function that reads from the table and validates if the code can currently be used. 

### Known Issues
There was an issue where after a deployment or bot not being used in awhile the code would not be sent out and an error code of 404 would be returned. I believe to have fixed this bug but it still might be present in the validation if so I will fix it when I go to implement user stuff. 